### PR TITLE
added -id option for setting input delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lcNrD v1.6
+# lcNrD v1.6.5
 
 lowercase AND remove Duplicates - A Very Simple Program;
 
@@ -8,6 +8,7 @@ I find myself having to clean up data quite often & lose python scripts that I w
 As it stands, this program works best with text listed using the '\n' delimiter. I plan to soon add more delimiter options
 
 ## Current Functionality:
+* Set input delimiter
 * Lowercase the text of a file
 * Remove duplicates of a file
 * Copy all operations onto a new file
@@ -25,6 +26,8 @@ As it stands, this program works best with text listed using the '\n' delimiter.
                         treatment (default: None)
   -o OUT, --out OUT     this is the file you want the lcNrD file to output as.
                         Default = same name + _LcNrD (default: None)
+  -id INPUT_DELIMITER, --input_delimiter INPUT_DELIMITER
+                        this is the delimiter you want lcNrD to use for the
   -l, --lowercase       add -l to set lowercase to true (default: False)
   -d, --duplicates      add -d to remove duplicate elements (default: False)
   -s, --shuffle         add -s to shuffle your list (default: False)
@@ -71,5 +74,4 @@ If you'd like to be able to access lcnrd from anywhere on your computer, add the
 7. You should now from anywhere on your computer be able to type simply `lcnrd -h` from a terminal & it should work!
 
 ## Roadmap:
-* Add input delimiter
 * Add output delimiter

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As it stands, this program works best with text listed using the '\n' delimiter.
                         Default = same name + _LcNrD (default: None)
   -id INPUT_DELIMITER, --input_delimiter INPUT_DELIMITER
                         this is the delimiter you want lcNrD to use for the
-  -l, --lowercase       add -l to set lowercase to true (default: False)
+                        input file (default: \n)
   -d, --duplicates      add -d to remove duplicate elements (default: False)
   -s, --shuffle         add -s to shuffle your list (default: False)
   -rf, --replace_file   add -rf to replace the original file after lcnrd

--- a/lcNrD.py
+++ b/lcNrD.py
@@ -12,6 +12,8 @@ parser.add_argument(
     help='** this is the file you\'re targeting to get the lcNrD treatment')
 parser.add_argument("-o", "--out", type=str,
     help='this is the file you want the lcNrD file to output as. Default = same name + _LcNrD')
+parser.add_argument("-id", "--input_delimiter", type=str, default='\\n',
+    help='this is the delimiter you want lcNrD to use for the input file')
 
 # store true or false so we can just be like 'if args.lowercase:'
 # so use true or false values instead of comparing strings
@@ -41,6 +43,11 @@ parser.add_argument('-kae', "--keyword_add_end", type=str,
     help='add a -kae to add some text to the end of every line')
 args = parser.parse_args()
 
+# check if input_delimiter is set to default & if so rectify escape character
+# this escapse character is left in so that the default value displays correctly in -h
+if(args.input_delimiter == "\\n"):
+    args.input_delimiter = "\n"
+
 print('Grabbing file contents...')
 
 # open the target file & grab its contents. Using `with` like this automatically
@@ -49,7 +56,7 @@ with open(args.file, "r") as fp:
     text = fp.read()
 
 # let's create an array of the lines
-lines = text.split("\n")
+lines = text.split(args.input_delimiter)
 
 # Remove blank lines
 if args.blank_lines:


### PR DESCRIPTION
added new argument "-id" along with help message and default "\\n".
added a check for rectifying delimiter default from "\\n" to "\n".
included comment for explaining default check & rectification.